### PR TITLE
Whitelisting local file paths

### DIFF
--- a/lib/pdfgen.rb
+++ b/lib/pdfgen.rb
@@ -13,7 +13,7 @@ MAKE_PDF_COMMAND = File.expand_path('../javascript_bin/make_pdf.js', __FILE__)
 
 class Pdfgen
   def initialize(html_or_url)
-    if html_or_url =~ /\Ahttp/
+    if html_or_url =~ /\Ahttp|\Afile/
       @url = html_or_url
       @html = nil
     else


### PR DESCRIPTION
This allows resolving the actual files on the local FS (for example when html file is generated and saved locally before Pdfgen is called).